### PR TITLE
fix a bug in apt-helper.js

### DIFF
--- a/src/tool/api-helper.js
+++ b/src/tool/api-helper.js
@@ -26,7 +26,7 @@ const preprocessResponse = (response) => {
   if (token) {
     Cookies.set('token', token, {expires: 1});
   }
-  return response.json((data) => {
+  return response.json().then((data) => {
     try {
       // Login credential is expired.
       if (data.status.code.toString().startsWith('401')) {


### PR DESCRIPTION
**所有借助 `api-helper.js` 取回的数据，现在都有 `data.status.code`。**

如果后端未能提供，设定为 `5001` 。此时，控制台会打印出后端实际返回的内容。